### PR TITLE
feat(package): include react and test utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,5 +76,9 @@
   },
   "devDependencies": {
     "ta-scripts": "^2.4.3"
+  },
+  "peerDependencies": {
+    "react": ">=15",
+    "react-addons-test-utils": ">=15"
   }
 }


### PR DESCRIPTION
This PR adds `react-addons-test-utils` to peer deps.  This package is required in order for `gen test` to run, due to it being a peer dep of `enzyme`.

Even though the user is likely to have already added React, since Genesis is for compiling React apps, I've also added it as a peer dep for good measure.

---

We should really consider including this in Genesis deps.  It is part of the test rig, just like Karma etc.  The `gen test` command will not work without it.  Otherwise, bootstrapping an app consists of installing Genesis then also `npm i react-addons-test-utils -D`:

``` json
  "devDependencies": {
    "@technologyadvice/genesis": "^1.0.1",
    "react-addons-test-utils": "^15.3.2"
  },
```

Why didn't I?  Because, technically that would mean we should also bundle React since the test utils only work against the same version of React.  This is a larger convo.
