### PR TITLE
fix(config): prevent cli defaults from overriding config

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -12,7 +12,7 @@ const log = require('./lib/log')
 // Parse Args
 // ==================================================
 debug('Parsing args')
-const argv = yargs
+let argv = yargs
   .commandDir('commands')
   .completion()
   .demand(1, 'You must specify a command')
@@ -170,12 +170,13 @@ const invoke = function invoke(env) {
     _.filter(_.isString),
     _.uniq
   )(env.configFiles)
+  debug('Found config files:', configFilePaths)
 
   // Add final config to argv.
-  // Use configName file or first configFiles path found.
+  // Use default configName file or first configFiles path found.
   const config = env.configPath || _.first(configFilePaths)
-  yargs.parse(process.argv, { config })
-  debug('argv:', JSON.stringify(yargs.argv, null, 2))
+  argv = yargs.parse(process.argv.slice(2), { config })
+  debug('Updated argv with first config file:', JSON.stringify(argv, null, 2))
 
   // ----------------------------------------
   // Execute Command

--- a/commands/build.js
+++ b/commands/build.js
@@ -17,7 +17,6 @@ module.exports = {
       .group(['s'], 'Compiler:')
       .option('s', {
         alias: 'sourcemaps',
-        default: configSchema.compiler_sourcemaps.default,
         describe: configSchema.compiler_sourcemaps.describe,
         type: configSchema.compiler_sourcemaps.type,
       })

--- a/commands/start.js
+++ b/commands/start.js
@@ -12,13 +12,11 @@ module.exports = {
       .group(['h', 'p'], 'Server:')
       .option('p', {
         alias: 'port',
-        default: configSchema.server_port.default,
         describe: configSchema.server_port.describe,
         type: configSchema.server_port.type,
       })
       .option('h', {
         alias: 'host',
-        default: configSchema.server_host.default,
         describe: configSchema.server_host.describe,
         type: configSchema.server_host.type,
       })

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -4,5 +4,5 @@ const _ = require('lodash/fp')
 
 const defaultConfig = _.mapValues('default', configSchema)
 
-debug(`Generated default config ${JSON.stringify(defaultConfig, null, 2)}`)
+debug(`Generated default config = ${JSON.stringify(defaultConfig, null, 2)}`)
 module.exports = defaultConfig

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -26,18 +26,18 @@ module.exports = function getConfig(configPath = null, overrides = {}) {
   // ----------------------------------------
   // Project Config
   // ----------------------------------------
-  debug('Loading project config')
   let projectConfig = {}
 
   if (!configPath) {
     debug('No config specified')
+    log.info('Using default config')
   } else {
     debug(`Trying to load config ${configPath}`)
 
     try {
-      projectConfig = require(configPath)
+      projectConfig = require(paths.cwdRoot(configPath))
       debug('Config loaded')
-      log.info(`Loaded config ${chalk.magenta(configPath)}`)
+      log.info(`Using config ${configPath}`)
 
       validators.projectConfig(projectConfig)
     } catch (err) {
@@ -46,6 +46,14 @@ module.exports = function getConfig(configPath = null, overrides = {}) {
       throw err
     }
   }
+  debug(`Project config = ${JSON.stringify(projectConfig, null, 2)}`)
+
+  // ----------------------------------------
+  // Overrides
+  // ----------------------------------------
+  debug('Scrubbing override config')
+  const overrideConfig = _.omitBy(_.isUndefined, overrides)
+  debug(`Override config = ${JSON.stringify(overrideConfig, null, 2)}`)
 
   // ----------------------------------------
   // Environment
@@ -64,6 +72,14 @@ module.exports = function getConfig(configPath = null, overrides = {}) {
   if (!overrides.compiler_env && !projectConfig.compiler_env && !process.env.NODE_ENV) {
     log.info(`Using default compiler_env=${__ENV__}`)
   }
+  debug(`Environment globals = ${JSON.stringify({
+    __ENV__,
+    __DEV__,
+    __TEST__,
+    __STAG__,
+    __PROD__,
+    NODE_ENV,
+  }, null, 2)}`)
 
   // ----------------------------------------
   // Required Config
@@ -121,6 +137,7 @@ module.exports = function getConfig(configPath = null, overrides = {}) {
     server_protocol: 'http',
     test_entry: paths.genTest('main.test.js'),
   }
+  debug(`Required config = ${JSON.stringify(requiredConfig, null, 2)}`)
 
   // ----------------------------------------
   // Final Config
@@ -130,9 +147,9 @@ module.exports = function getConfig(configPath = null, overrides = {}) {
     {},
     defaultConfig,
     projectConfig,
-    _.omitBy(_.isUndefined, overrides),
+    overrideConfig,
     requiredConfig
   )
-  debug(`Final config ${JSON.stringify(finalConfig, null, 2)}`)
+  debug(`Final config = ${JSON.stringify(finalConfig, null, 2)}`)
   return finalConfig
 }


### PR DESCRIPTION
This PR updates the config buildup so that the CLI defaults do not override the config file values.  It also adds more debugging logs to help diagnose issues.
