### PR TITLE
feat(test): use resolve plugin for mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,21 +137,24 @@ describe('genesis test harness', () => {
 
 ### Mocks
 
-Any module added to `/test/mocks` will replace real modules of the same name during tests.  Let's mock a fictitious `src/lib/ajax-module.js` during tests:
-
-```
-/test/mocks/ajax-module.js
-```
-
-Now, `gen test` will resolve all `import ajaxModule from 'ajax-module'` statements to the mock module instead of the real one.
-  
-Mocking a 3rd party library works the same.  If we want to mock `axios` during tests:
+Any module added to `/test/mocks` will replace real modules of the same name during tests.  If we want to mock `axios` during tests:
 
 ```
 /test/mocks/axios.js
 ```
 
 Now, all `import axios from 'axios'` statements will resolve to our mocked axios module instead of the one in `node_modules`.
+
+#### Scoped Modules
+
+Mock scoped modules by replicating NPM's scoped directory:  If we want to mock `@my-scope/my-module` during tests:
+
+```
+/test/mocks/@my-scope/my-module.js
+```
+
+Now, all `import myModule from '@my-scope/my-module'` statements will resolve to our mocked module instead of the one in `node_modules`.
+
 
 ### Stack
 

--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 const { handleError } = require('./lib/utils')
+const chalk = require('chalk')
 const debug = require('debug')('genesis:cli')
 const { extensions } = require('interpret')
 const Liftoff = require('liftoff')
@@ -149,7 +150,7 @@ const invoke = function invoke(env) {
   // ----------------------------------------
   if (process.cwd() !== env.cwd) {
     process.chdir(env.cwd)
-    log.info('Working directory changed to', env.cwd)
+    log.info('Working directory changed to', chalk.blue(env.cwd))
   }
 
   // ----------------------------------------

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -1,3 +1,4 @@
+const chalk = require('chalk')
 const debug = require('debug')('genesis:get-config')
 const _ = require('lodash/fp')
 const log = require('./log')
@@ -36,7 +37,7 @@ module.exports = function getConfig(configPath = null, overrides = {}) {
     try {
       projectConfig = require(paths.cwdRoot(configPath))
       debug('Config loaded')
-      log.info(`Using config ${configPath}`)
+      log.info(`Using config ${chalk.blue(configPath)}`)
 
       validators.projectConfig(projectConfig)
     } catch (err) {
@@ -66,10 +67,10 @@ module.exports = function getConfig(configPath = null, overrides = {}) {
   const NODE_ENV = process.env.NODE_ENV || __ENV__
 
   if (!process.env.NODE_ENV) {
-    log.info(`Using default NODE_ENV=${NODE_ENV}`)
+    log.info(`Using default ${chalk.blue(`NODE_ENV=${NODE_ENV}`)}`)
   }
   if (!overrides.compiler_env && !projectConfig.compiler_env && !process.env.NODE_ENV) {
-    log.info(`Using default compiler_env=${__ENV__}`)
+    log.info(`Using default ${chalk.blue(`compiler_env=${__ENV__}`)}`)
   }
   debug(`Environment globals = ${JSON.stringify({
     __ENV__,

--- a/lib/get-webpack-config.js
+++ b/lib/get-webpack-config.js
@@ -91,21 +91,26 @@ module.exports = function getWebpackConfig(config, options) {
     debug(`Test mock paths = ${JSON.stringify(mockFiles, null, 2)}`)
 
     if (mockFiles.length > 0) {
-      const longestKey = _.max(_.map('length', mockFiles))
-      let infoMessage = 'Using mocked modules:'
+      const mockedModules = mockFiles.map(file => file.replace(path.extname(file), ''))
+      log.info(`Using mocks\n${mockedModules.map(x => `  - ${chalk.blue(x)}`).join('\n')}`)
 
-      mockFiles.forEach(file => {
-        const moduleName = path.basename(file, path.extname(file))
-        const mockPath = paths.cwdMocks(moduleName)
+      class MockModulePlugin {
+        apply(compiler) {
+          // The 'module' plugin here is only passed node_module requests, not local modules
+          compiler.resolvers.normal.plugin('module', function mockModulePlugin(request, callback) {
+            const isMocked = mockedModules.some(mockedModule => _.includes(mockedModule, request.request))
 
-        // inform the user
-        infoMessage += `\n  - ${_.padEnd(longestKey, path.basename(moduleName))} ${chalk.gray('=>')} ${mockPath}`
+            if (isMocked) {
+              request.path = paths.cwdMocks()
+              this.doResolve(['file'], request, callback)
+            } else {
+              callback()
+            }
+          })
+        }
+      }
 
-        // add alias
-        webpackConfig.resolve.alias[moduleName] = mockPath
-      })
-
-      log.info(infoMessage)
+      webpackConfig.plugins.push(new MockModulePlugin())
     }
   }
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -14,7 +14,7 @@ const print = (stream, color, symbol, ...msgs) => {
       : msg
   })
 
-  const line = `${color(symbol)} ${formattedMessages.join('')}`
+  const line = `${color(symbol)} ${formattedMessages.join(' ')}`
   return process[stream].write(line)
 }
 


### PR DESCRIPTION
This PR handles scoped modules which have paths in their name:
`@technologyadvice/ta-client` resolves to `test/mocks/@technologyadvice/ta-client`

It also:
- Uses a resolve plugin to find mocks, instead of alias config
- Fixes some issues with the logging output
