### PR TITLE
fix(get-config): merge project config globals

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -92,7 +92,8 @@ module.exports = function getConfig(configPath = null, overrides = {}) {
     compiler_assets: paths.cwdAssets(),
     compiler_favicon: paths.cwdAssets('favicon.png'),
     compiler_dist: paths.cwdDist(),
-    compiler_globals: {
+    // merge projectConfig.compiler_globals
+    compiler_globals: Object.assign({}, projectConfig.compiler_globals, {
       __APP_ENTRY_SRC_PATH__: JSON.stringify(`.${path.sep}${appEntryFilename}`),
       __CWD_SPECS_DIR__: JSON.stringify(paths.cwdSpecs()),
       __CWD_SRC_DIR__: JSON.stringify(paths.cwdSrc()),
@@ -101,12 +102,12 @@ module.exports = function getConfig(configPath = null, overrides = {}) {
       __TEST__,
       __STAG__,
       __PROD__,
-      process: {
-        env: {
+      process: Object.assign({}, projectConfig.compiler_globals.process, {
+        env: Object.assign({}, projectConfig.compiler_globals.process.env, {
           NODE_ENV: JSON.stringify(NODE_ENV),
-        },
-      },
-    },
+        }),
+      }),
+    }),
     compiler_src: paths.cwdSrc(),
     compiler_fail_on_warning: !__DEV__,
     compiler_autoprefixer: {


### PR DESCRIPTION
Fixes #54 

This PR merges project config globals with the required globals, so the user can add `process.env` globals without being overriden.