### PR TITLE
fix(get-config): _.merge all configs

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -91,20 +91,19 @@ module.exports = function getConfig(configPath = null, overrides = {}) {
     compiler_assets: paths.cwdAssets(),
     compiler_favicon: paths.cwdAssets('favicon.png'),
     compiler_dist: paths.cwdDist(),
-    // merge projectConfig.compiler_globals
-    compiler_globals: Object.assign({}, projectConfig.compiler_globals, {
+    compiler_globals: {
       __CWD_SPECS_DIR__: JSON.stringify(paths.cwdSpecs()),
       __ENV__: JSON.stringify(__ENV__),
       __DEV__,
       __TEST__,
       __STAG__,
       __PROD__,
-      process: Object.assign({}, projectConfig.compiler_globals.process, {
-        env: Object.assign({}, projectConfig.compiler_globals.process.env, {
+      process: {
+        env: {
           NODE_ENV: JSON.stringify(NODE_ENV),
-        }),
-      }),
-    }),
+        },
+      },
+    },
     compiler_src: paths.cwdSrc(),
     compiler_fail_on_warning: !__DEV__,
     compiler_autoprefixer: {
@@ -146,13 +145,13 @@ module.exports = function getConfig(configPath = null, overrides = {}) {
   // Final Config
   // ----------------------------------------
   debug('Merging final config')
-  const finalConfig = Object.assign(
-    {},
+  // Merge to preserve nested keys in multiple configs (e.g. `compiler_globals.process.env.NODE_ENV)`.
+  const finalConfig = [
     defaultConfig,
     projectConfig,
     overrideConfig,
-    requiredConfig
-  )
+    requiredConfig,
+  ].reduce(_.merge)
   debug(`Final config = ${JSON.stringify(finalConfig, null, 2)}`)
   return finalConfig
 }


### PR DESCRIPTION
The previous PR to merge compiler_globals was naive and did not check for the presence of `process` and `process.env` before accessing them.  This resulted in throwing if you did not include them in your project config.

It was also short sighted as it only merged the globals, no other config.  This PR resolves both issues by using `_.merge` to merge all configs.  This handles the maybe case and also handles any other nested config that may arise.

I've also tested both cases (with project config and without) against Unity and all is well.  Really need some proper tests in this project ... :/